### PR TITLE
Make PDF generation canvas async

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,11 +463,11 @@
       <h2 id="redes-titulo">Para ver más de mi portafolio</h2>
       <div class="redes-links">
         <a href="https://www.instagram.com/_fanru_/" target="_blank" rel="noopener noreferrer" class="red-social">
-          <img src="https://img.icons8.com/fluency/48/000000/instagram-new.png" alt="Instagram" width="48" height="48">
+          <img src="https://img.icons8.com/fluency/48/000000/instagram-new.png" alt="Instagram" width="48" height="48" crossorigin="anonymous">
           <span>Instagram</span>
         </a>
         <a href="https://www.behance.net/fanruantonio" target="_blank" rel="noopener noreferrer" class="red-social">
-          <img src="https://img.icons8.com/color/48/000000/behance.png" alt="Behance" width="48" height="48">
+          <img src="https://img.icons8.com/color/48/000000/behance.png" alt="Behance" width="48" height="48" crossorigin="anonymous">
           <span>Behance</span>
         </a>
       </div>

--- a/script.js
+++ b/script.js
@@ -465,15 +465,18 @@ document.addEventListener('keydown', function(event) {
 
 const pdfBtn = document.getElementById('descargar-pdf');
 if (pdfBtn) {
-    pdfBtn.addEventListener('click', () => {
-        html2canvas(document.body).then(canvas => {
-            const imgData = canvas.toDataURL('image/png');
-            const { jsPDF } = window.jspdf;
-            const pdf = new jsPDF('p', 'mm', 'a4');
-            const pdfWidth = pdf.internal.pageSize.getWidth();
-            const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
-            pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
-            pdf.save('curriculum.pdf');
+    pdfBtn.addEventListener('click', async () => {
+        const canvas = await html2canvas(document.body, {
+            useCORS: true,
+            scrollY: -window.scrollY,
+            scale: 2
         });
+        const imgData = canvas.toDataURL('image/png');
+        const { jsPDF } = window.jspdf;
+        const pdf = new jsPDF('p', 'mm', 'a4');
+        const pdfWidth = pdf.internal.pageSize.getWidth();
+        const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
+        pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+        pdf.save('curriculum.pdf');
     });
 }


### PR DESCRIPTION
## Summary
- Make PDF generation async with html2canvas CORS and scaling
- Add anonymous cross-origin attributes to external images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bfe28c108328b9695bcd0f216c81