### PR TITLE
Generate JPEG when exporting PDF

### DIFF
--- a/script.js
+++ b/script.js
@@ -471,12 +471,12 @@ if (pdfBtn) {
             scrollY: -window.scrollY,
             scale: 2
         });
-        const imgData = canvas.toDataURL('image/png');
+        const imgData = canvas.toDataURL('image/jpeg', 0.7);
         const { jsPDF } = window.jspdf;
         const pdf = new jsPDF('p', 'mm', 'a4');
         const pdfWidth = pdf.internal.pageSize.getWidth();
         const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
-        pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+        pdf.addImage(imgData, 'JPEG', 0, 0, pdfWidth, pdfHeight);
         pdf.save('CV-FernandoAntonioRuiz.pdf');
     });
 }


### PR DESCRIPTION
## Summary
- Switch canvas export to generate JPEG with quality 0.7
- Update jsPDF call to embed JPEG instead of PNG

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c17d44448328a283113c42868fc9